### PR TITLE
fix: holograms appear as visible armor stands on first join

### DIFF
--- a/src/main/java/kireiko/dev/anticheat/listeners/EntityTrackerListener.java
+++ b/src/main/java/kireiko/dev/anticheat/listeners/EntityTrackerListener.java
@@ -1,144 +1,39 @@
 package kireiko.dev.anticheat.listeners;
 
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
-import com.comphenix.protocol.events.ListenerPriority;
-import com.comphenix.protocol.events.PacketAdapter;
-import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.events.PacketEvent;
+import com.destroystokyo.paper.event.entity.EntityAddToWorldEvent;
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import kireiko.dev.anticheat.MX;
 import kireiko.dev.anticheat.utils.cache.EntityCache;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerQuitEvent;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Supplier;
 
 /**
- * Populates {@link EntityCache} via outgoing server packets.
- * Compatible with 1.8 .. 1.21+ (uses isSupported() guards on legacy packet types).
+ * Populates {@link EntityCache} from Paper's add/remove-to-world events. We do
+ * NOT touch the netty pipeline — packet-only entities from hologram plugins
+ * (DecentHolograms etc.) are simply not real Bukkit entities and never enter
+ * the cache, which is exactly what combat checks want.
  */
 public final class EntityTrackerListener implements Listener {
 
     public static void register() {
-        registerSpawnListener();
-        registerDestroyListener();
-        registerRespawnListener();
         Bukkit.getPluginManager().registerEvents(new EntityTrackerListener(), MX.getInstance());
+        // Pre-populate with entities already loaded at plugin enable.
+        for (World world : Bukkit.getWorlds()) {
+            for (Entity e : world.getEntities()) EntityCache.track(e);
+        }
     }
 
-    private static void registerSpawnListener() {
-        List<PacketType> spawn = new ArrayList<>();
-        addIfSupported(spawn, () -> PacketType.Play.Server.SPAWN_ENTITY);
-        addIfSupported(spawn, () -> PacketType.Play.Server.SPAWN_ENTITY_LIVING);
-        addIfSupported(spawn, () -> PacketType.Play.Server.NAMED_ENTITY_SPAWN);
-        addIfSupported(spawn, () -> PacketType.Play.Server.SPAWN_ENTITY_PAINTING);
-        addIfSupported(spawn, () -> PacketType.Play.Server.SPAWN_ENTITY_EXPERIENCE_ORB);
-        if (spawn.isEmpty()) return;
-
-        ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(
-                MX.getInstance(),
-                ListenerPriority.MONITOR,
-                spawn.toArray(new PacketType[0])
-        ) {
-            @Override
-            public void onPacketSending(PacketEvent event) {
-                // Hot path on netty thread — keep it microsecond-cheap.
-                final int id;
-                final Player player;
-                final World world;
-                try {
-                    PacketContainer p = event.getPacket();
-                    if (p.getIntegers().size() == 0) return;
-                    id = p.getIntegers().read(0);
-                    player = event.getPlayer();
-                    if (player == null) return;
-                    world = player.getWorld();
-                } catch (Throwable t) { return; }
-
-                // Heavy entity resolution off the netty pipeline.
-                Bukkit.getScheduler().runTask(MX.getInstance(), () -> {
-                    try {
-                        Entity entity = ProtocolLibrary.getProtocolManager()
-                                                       .getEntityFromID(world, id);
-                        if (entity != null) EntityCache.track(player, id, entity);
-                    } catch (Throwable ignored) {}
-                });
-            }
-        });
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onAdd(EntityAddToWorldEvent e) {
+        EntityCache.track(e.getEntity());
     }
 
-    private static void registerDestroyListener() {
-        ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(
-                MX.getInstance(),
-                ListenerPriority.MONITOR,
-                PacketType.Play.Server.ENTITY_DESTROY
-        ) {
-            @Override
-            public void onPacketSending(PacketEvent event) {
-                try {
-                    PacketContainer p = event.getPacket();
-                    Player player = event.getPlayer();
-                    if (player == null) return;
-
-                    // 1.17.1+ : List<Integer>
-                    try {
-                        if (p.getIntLists().size() > 0) {
-                            List<Integer> ids = p.getIntLists().read(0);
-                            if (ids != null) for (int id : ids) EntityCache.untrack(player, id);
-                            return;
-                        }
-                    } catch (Throwable ignored) {}
-
-                    // <= 1.16.5 : int[]
-                    try {
-                        if (p.getIntegerArrays().size() > 0) {
-                            int[] ids = p.getIntegerArrays().read(0);
-                            if (ids != null) for (int id : ids) EntityCache.untrack(player, id);
-                            return;
-                        }
-                    } catch (Throwable ignored) {}
-
-                    // 1.17.0 : single int
-                    if (p.getIntegers().size() > 0) {
-                        EntityCache.untrack(player, p.getIntegers().read(0));
-                    }
-                } catch (Throwable ignored) {}
-            }
-        });
-    }
-
-    private static void registerRespawnListener() {
-        ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(
-                MX.getInstance(),
-                ListenerPriority.MONITOR,
-                PacketType.Play.Server.RESPAWN
-        ) {
-            @Override
-            public void onPacketSending(PacketEvent event) {
-                try {
-                    Player player = event.getPlayer();
-                    if (player != null) EntityCache.clearTracked(player);
-                } catch (Throwable ignored) {}
-            }
-        });
-    }
-
-    private static void addIfSupported(List<PacketType> list, Supplier<PacketType> s) {
-        PacketType t;
-        try { t = s.get(); } catch (Throwable ignored) { return; }
-        if (t == null) return;
-        try { if (t.isSupported()) list.add(t); } catch (Throwable ignored) {}
-    }
-
-    @EventHandler
-    public void onQuit(PlayerQuitEvent e) {
-        EntityCache.forget(e.getPlayer());
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onRemove(EntityRemoveFromWorldEvent e) {
+        EntityCache.untrack(e.getEntity().getEntityId());
     }
 }

--- a/src/main/java/kireiko/dev/anticheat/listeners/UseEntityListener.java
+++ b/src/main/java/kireiko/dev/anticheat/listeners/UseEntityListener.java
@@ -38,7 +38,7 @@ public final class UseEntityListener extends PacketAdapter {
                         EnumWrappers.EntityUseAction.ATTACK);
         if (packet.getIntegers().getValues().isEmpty()) return;
         int entityId = packet.getIntegers().read(0);
-        Entity entity = EntityCache.get(player, entityId);
+        Entity entity = EntityCache.get(entityId);
         if (profile.getAttackBlockToTime() > System.currentTimeMillis()) {
             if (ConfigCache.PREVENTION > 0) {
                 event.setCancelled(true);
@@ -50,8 +50,9 @@ public final class UseEntityListener extends PacketAdapter {
                                 && attack
                                 && entity instanceof LivingEntity
                                 && player.getLocation().toVector().distance(entity.getLocation().toVector()) < 3.3) {
+                    final LivingEntity target = (LivingEntity) entity;
                     Bukkit.getScheduler().runTask(MX.getInstance(), () -> {
-                        ((LivingEntity) entity).damage(0.5, player);
+                        target.damage(0.5, player);
                     });
                 }
                 profile.debug("UseEntity packet blocked");

--- a/src/main/java/kireiko/dev/anticheat/utils/cache/EntityCache.java
+++ b/src/main/java/kireiko/dev/anticheat/utils/cache/EntityCache.java
@@ -1,53 +1,45 @@
 package kireiko.dev.anticheat.utils.cache;
 
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
 
 import java.lang.ref.WeakReference;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Per-player entity tracking cache populated from outgoing spawn/destroy packets.
- * Lookup is fully async-safe and O(1) — no NMS / reflection on the hot path.
+ * Global entity-id → Entity cache. Bukkit assigns entity IDs from a single static
+ * counter, so they are unique across all worlds — a flat map is enough.
+ *
+ * <p>Lookups are O(1) and lock-free. Populated proactively from Bukkit spawn
+ * events (no packet interception), so first-attack latency is zero.
  */
 public final class EntityCache {
 
     private EntityCache() {}
 
-    private static final Map<UUID, Map<Integer, WeakReference<Entity>>> BY_PLAYER = new ConcurrentHashMap<>();
+    private static final Map<Integer, WeakReference<Entity>> CACHE = new ConcurrentHashMap<>();
 
-    public static Entity get(Player player, int entityId) {
-        Map<Integer, WeakReference<Entity>> m = BY_PLAYER.get(player.getUniqueId());
-        if (m == null) return null;
-        WeakReference<Entity> ref = m.get(entityId);
+    public static Entity get(int entityId) {
+        WeakReference<Entity> ref = CACHE.get(entityId);
         if (ref == null) return null;
         Entity e = ref.get();
         if (e == null) {
-            m.remove(entityId);
+            CACHE.remove(entityId);
             return null;
         }
         return e;
     }
 
-    public static void track(Player player, int entityId, Entity entity) {
+    public static void track(Entity entity) {
         if (entity == null) return;
-        BY_PLAYER.computeIfAbsent(player.getUniqueId(), k -> new ConcurrentHashMap<>())
-                 .put(entityId, new WeakReference<>(entity));
+        CACHE.put(entity.getEntityId(), new WeakReference<>(entity));
     }
 
-    public static void untrack(Player player, int entityId) {
-        Map<Integer, WeakReference<Entity>> m = BY_PLAYER.get(player.getUniqueId());
-        if (m != null) m.remove(entityId);
+    public static void untrack(int entityId) {
+        CACHE.remove(entityId);
     }
 
-    public static void clearTracked(Player player) {
-        Map<Integer, WeakReference<Entity>> m = BY_PLAYER.get(player.getUniqueId());
-        if (m != null) m.clear();
-    }
-
-    public static void forget(Player player) {
-        BY_PLAYER.remove(player.getUniqueId());
+    public static void clear() {
+        CACHE.clear();
     }
 }


### PR DESCRIPTION
## Проблема

При появлении игрока на сервере, если в радиусе видимости находятся голограммы DecentHolograms (или другого плагина, использующего packet-only ArmorStand), они отображаются как **видимые арморстенды** вместо невидимых держателей имени. Если отойти за пределы tracking range и подойти снова — голограммы перерисовываются корректно.

Регрессия появилась в **5.4** вместе с новыми `EntityTrackerListener` и `EntityCache`.

## Корневая причина

В 5.4 для оптимизации lookup-а сущностей в `UseEntityListener` (раньше — синхронный `getEntityFromID` на каждый USE_ENTITY) был добавлен packet-listener на исходящие `SPAWN_ENTITY` / `SPAWN_ENTITY_LIVING` / `NAMED_ENTITY_SPAWN` через ProtocolLib.

В 1.16.5 сам флаг `Invisible 0x20` физически отсутствует в `SPAWN_ENTITY_LIVING` — Mojang вынес метадату в отдельный `ENTITY_METADATA` ещё в 1.15. То есть мы не «теряем байт» при чтении пакета.

Однако сама регистрация listener-а на эти типы пакетов заставляет ProtocolLib встраивать netty-handler в pipeline каждого игрока. На первом джойне, когда соединение ещё проходит фазу инициализации, обёртывание исходящих spawn-пакетов в `PacketContainer` интерферирует с packet-flow DecentHolograms — отдельный `ENTITY_METADATA` с invisibility-битом, идущий сразу после спауна, либо теряется, либо доходит до клиента раньше самого спауна и игнорируется.

Подтверждение: фильтрация по `EntityType.ARMOR_STAND` внутри обработчика **не помогает** — повреждение происходит на этапе ProtocolLib-обёртывания пакета, до вызова listener-кода. Помогает только полное снятие подписки на исходящие spawn-пакеты.

## Решение

Полностью убран intercept исходящих пакетов. \`EntityCache\` теперь наполняется проактивно через Bukkit-события Paper:

- \`EntityAddToWorldEvent\` — добавление сущности в мир (спаун, загрузка чанка, телепорт между мирами)
- \`EntityRemoveFromWorldEvent\` — удаление сущности (despawn, смерть, выгрузка чанка)
- На \`onEnable\` — однократный скан уже загруженных миров

Структура кеша упрощена: вместо \`Map<UUID(Player), Map<Integer, WeakRef<Entity>>>\` — плоский \`Map<Integer, WeakRef<Entity>>\`. ID сущностей в Bukkit/Paper уникальны на всём сервере (один статический счётчик в NMS), per-player и per-world разделение не требуется.

\`UseEntityListener\` теперь делает чистый O(1) \`EntityCache.get(entityId)\` без fallback-а — кеш всегда заполнен заранее, первая атака по сущности ни на йоту не медленнее последующих.